### PR TITLE
chore: new version

### DIFF
--- a/optizone/versions.yaml
+++ b/optizone/versions.yaml
@@ -9,6 +9,13 @@ application:
   envs: [staging, qa, preprod, prod]
 
   versions:
+    3.24.3:
+      backend:
+        image: aixpand/backend:release-3.35.6
+      frontend:
+        image: aixpand/investigator:optizone-0.88.5
+      summary: |
+        fix: MQTT subscriptions clashing with callbacks;
     3.24.2:
       backend:
         image: aixpand/backend:release-3.35.5


### PR DESCRIPTION
https://github.com/gtscavi/cavi2/commit/15836aa2f236b135041390ca63de357968f2569c

subscription string-ul era alocat si callbackului, dar MQTT nu mai trimite prefixul in callback.

am spart in 2 variabile diferite pentru a trata problema de subscription.